### PR TITLE
Adds "From:" and "To:" headers.

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNMailCoreModule.java
+++ b/android/src/main/java/com/reactlibrary/RNMailCoreModule.java
@@ -57,15 +57,17 @@ public class RNMailCoreModule extends ReactContextBaseJavaModule {
         toAddress.setDisplayName(toObj.getString("addressWithDisplayName"));
         toAddress.setMailbox(toObj.getString("mailbox"));
 
+        ArrayList<Address> toAddressList = new ArrayList();
+        toAddressList.add(toAddress);
+
         MessageHeader messageHeader = new MessageHeader();
         messageHeader.setSubject(obj.getString("subject"));
+        messageHeader.setTo(toAddressList);
+        messageHeader.setFrom(fromAddress);
 
         MessageBuilder messageBuilder = new MessageBuilder();
         messageBuilder.setHeader(messageHeader);
         messageBuilder.setHTMLBody(obj.getString("htmlBody"));
-
-        ArrayList<Address> toAddressList = new ArrayList();
-        toAddressList.add(toAddress);
 
         SMTPOperation smtpOperation = smtpSession.sendMessageOperation(fromAddress, toAddressList, messageBuilder.data());
         smtpOperation.start(new OperationCallback() {


### PR DESCRIPTION
Without "From:" and "To:" headers, messages sent won't be RFC 5322 compliant, and as such providers like Gmail and SendGrid will block them from sending. 

Adding these is crucial for emails to be received. Below is a sample rejection notice from gmail:

```
550 5.7.1 [167.89.106.69 11] Our system has detected that this message is 5.7.1 not RFC 5322 compliant: 5.7.1 'From' header is missing. 5.7.1 To reduce the amount of spam sent to Gmail, this message has been 5.7.1 blocked. Please visit 5.7.1 https://support.google.com/mail/?p=RfcMessageNonCompliant 5.7.1 and review RFC 5322 specifications for more information. 
 - gsmtp
```